### PR TITLE
Tech4allBiz Edits Part 1

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -8,8 +8,8 @@ import Button from "@/app/ui/Buttons";
 
 const pageStyle = {
   container:
-    "w-full grid grid-cols-1 gap-6 md:grid-cols-2  md:gap-20 justify-items-center",
-  btnsContainer: "w-full flex gap-4 justify-items-left",
+    "w-full grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-20 justify-items-center",
+  btnsContainer: "w-full flex flex-col md:flex-row gap-4 justify-items-left",
 };
 
 export async function generateStaticParams() {
@@ -40,7 +40,7 @@ export default async function LessonPage({
       </section>
       <SkillsLearned skillsTags={lesson.frontmatter.skillsLearned} />
       <section className={pageStyle.btnsContainer}>
-        <Button variant="lessons" text="View More Lesson" href="/#lessons" />
+        <Button variant="lessons" text="View More Lessons" href="/#lessons" />
         <Button
           variant="secondary"
           text="Free Online Resources"

--- a/app/components/landing/LandingHero.tsx
+++ b/app/components/landing/LandingHero.tsx
@@ -5,7 +5,7 @@ const styles = {
   leftColumn: "basis-1/3 flex flex-col py-8",
   heading: "text-[42px] font-bold mb-4",
   paragraph: "mb-8",
-  buttonContainer: "flex flex-wrap gap-4",
+  buttonContainer: "w-full flex flex-col md:flex-row gap-4 justify-items-left",
   rightColumn: "border basis-1/2 flex",
   videoIframe: "w-full h-auto aspect-video",
 };

--- a/app/components/landing/LessonsGrid.tsx
+++ b/app/components/landing/LessonsGrid.tsx
@@ -35,7 +35,7 @@ export default async function LessonsGrid() {
               <div className={styles.lessonTimeContainer}>
                 By: {lesson.author}
                 <div className={styles.lessonTime}>
-                  <Image src={Clock} alt="Clock" />
+                  <Image src={Clock} alt="Clock" width={14} height={14} />
                   <p>{lesson.lessonTime}</p>
                 </div>
               </div>
@@ -45,7 +45,7 @@ export default async function LessonsGrid() {
               <Button
                 href={`/${lesson.slug}`}
                 variant="primary"
-                text="Lesson Details"
+                text="View Lesson Details"
                 className="w-full"
               />
             </div>

--- a/app/components/landing/LessonsGrid.tsx
+++ b/app/components/landing/LessonsGrid.tsx
@@ -17,7 +17,7 @@ const styles = {
     "flex flex-row justify-between gap-3 items-center py-3 text-sm text-black font-medium",
   lessonTime: "flex flex-row gap-2 items-center",
   lessonDescription: "line-clamp-3",
-  lessonLink: "pt-3",
+  buttonContainer: "w-full flex flex-col md:flex-row gap-4 justify-items-left",
 };
 
 export default async function LessonsGrid() {
@@ -41,11 +41,12 @@ export default async function LessonsGrid() {
               </div>
               <p className={styles.lessonDescription}>{lesson.description}</p>
             </div>
-            <div className={styles.lessonLink}>
+            <div className={styles.buttonContainer}>
               <Button
                 href={`/${lesson.slug}`}
                 variant="primary"
                 text="Lesson Details"
+                className="w-full"
               />
             </div>
           </div>

--- a/app/components/lesson/LessonHero.tsx
+++ b/app/components/lesson/LessonHero.tsx
@@ -1,7 +1,7 @@
 import { FrontmatterProps } from "@/app/constants/types";
 
 const styles = {
-  container: "w-full flex flex-col",
+  container: "w-full flex flex-col py-5",
   headerRow: "flex flex-row w-full",
   title: "md:basis-3/5 text-3xl bold",
   contentRow: "flex flex-col md:flex-row justify-between  w-full",
@@ -12,7 +12,7 @@ const styles = {
 
 export default function LessonHero({ frontmatter }: FrontmatterProps) {
   return (
-    <div className={styles.container}>
+    <section className={styles.container}>
       <div className={styles.headerRow}>
         <h1 className={styles.title}>{frontmatter.title}</h1>
         <div></div>
@@ -29,6 +29,6 @@ export default function LessonHero({ frontmatter }: FrontmatterProps) {
           >{`Total lesson time: ${frontmatter.lessonTime}`}</div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/app/components/lesson/LessonHero.tsx
+++ b/app/components/lesson/LessonHero.tsx
@@ -3,10 +3,10 @@ import { FrontmatterProps } from "@/app/constants/types";
 const styles = {
   container: "w-full flex flex-col",
   headerRow: "flex flex-row w-full",
-  title: "md:basis-2/5 text-3xl bold",
-  contentRow: "flex flex-col md:flex-row justify-between w-full",
-  description: "md:basis-2/5 mt-4 mb-4",
-  statsContainer: "flex flex-col mt-auto",
+  title: "md:basis-3/5 text-3xl bold",
+  contentRow: "flex flex-col md:flex-row justify-between  w-full",
+  description: "md:basis-3/5 mt-4 mb-4",
+  statsContainer: "flex flex-col align-top mt-4",
   statsItem: "",
 };
 
@@ -20,6 +20,7 @@ export default function LessonHero({ frontmatter }: FrontmatterProps) {
       <div className={styles.contentRow}>
         <div className={styles.description}>{frontmatter.description}</div>
         <div className={styles.statsContainer}>
+          <div className={styles.statsItem}>{`By: ${frontmatter.author}`}</div>
           <div
             className={styles.statsItem}
           >{`Number of Lesson Steps: ${frontmatter.steps}`}</div>

--- a/app/components/onlineResources/OnlineResourceCard.tsx
+++ b/app/components/onlineResources/OnlineResourceCard.tsx
@@ -1,10 +1,11 @@
 import { OnlineResourceCardProps } from "@/app/constants/types";
+import Buttons from "@/app/ui/Buttons";
 
 const styles = {
-  cardContainer: `flex flex-col gap-y-6`,
+  cardContainer: `w-full flex flex-col gap-y-6`,
   header: `basis-3 flex-grow-0 mb-3 font-bold text-2xl`,
   body: `flex-grow text-black`,
-  linkButton: `justify-item-end w-fit mt-auto inline-block bg-[#1282A2] text-white py-2 px-4 rounded hover:bg-[#0E6881] transition-colors text-center`,
+  buttonContainer: "w-full flex flex-col md:flex-row gap-4 justify-items-left",
 };
 
 export default function OnlineResourceCard({
@@ -16,14 +17,14 @@ export default function OnlineResourceCard({
     <div className={styles.cardContainer}>
       <div className={styles.header}>{title}</div>
       <p className={styles.body}>{description}</p>
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={styles.linkButton}
-      >
-        Visit Webpage
-      </a>
+      <div className={styles.buttonContainer}>
+        <Buttons
+          href={url}
+          variant="primary"
+          className="w-full"
+          text="Visit Webpage"
+        />
+      </div>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${inter.className}`}>
         <div
-          className={`w-full m-auto px-6 py-8 md:px-24 md:px-0 max-w-[1600px]`}
+          className={`w-full m-auto px-6 pb-10 md:px-24 md:px-0 max-w-[1600px]`}
         >
           <NavDesktop />
           <NavMobile />

--- a/app/online-resources/page.tsx
+++ b/app/online-resources/page.tsx
@@ -8,7 +8,7 @@ const pageStyles = {
   header: "md:basis-2/5 text-3xl bold",
   resourcesGrid:
     "grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-x-48 gap-y-20 py-5 md:py-10",
-  buttonContainer: "flex flex-row gap-4",
+  buttonContainer: "w-full flex flex-col md:flex-row gap-4 justify-items-left",
 };
 
 export default function OnlineResourcesPage() {


### PR DESCRIPTION
**Mobile** 
HomePage 
- [x] - Maybe we could move the logo and menu icon a little higher?
- [x] - I feel like the font sizes of the video host should be the same and if possible, the clock icon could be scaled to match the font sizes.
- [x] - I think the “Lesson Details” text is good and short, but maybe adding a “visit lesson page” shows a call to action? (This is not a strong preference.)

Lesson Pages
- [x] We could move the “title header” lower from the logo.
- [x] The “View More Lessons” and “ Free Online Resources” buttons are not consistent in size. I know the space is a little tight, but maybe we could reduce the button and font size similar to the “View Lessons” button on the Free Online Resources page.

**Desktop**
Lesson Pages
- [x] We could move “Number of Lesson Steps: 3 and Total Lesson Time: 3 minutes” up and align with the beginning of the paragraph on all the pages. 
- [x] On “Saving files in folder structure (Windows),” we could expand the paragraph content more to the right. 

