### PR TITLE
mobile nav fixes

### DIFF
--- a/app/components/nav/NavMobile.tsx
+++ b/app/components/nav/NavMobile.tsx
@@ -1,29 +1,29 @@
-"use client";
+'use client'
 
-import React, { useState } from "react";
-import Image from "next/image";
-import MobileLogo from "@/public/Mobile_Logo.svg";
-import Link from "next/link";
+import React, { useState } from 'react'
+import Image from 'next/image'
+import MobileLogo from '@/public/Mobile_Logo.svg'
+import Link from 'next/link'
 
 const styles = {
-  container: "relative md:hidden",
-  header: "flex justify-between items-center py-4",
-  logo: "h-14 w-14",
-  hamburgerIcon: "w-6 h-6",
+  container: 'relative md:hidden',
+  header: 'flex justify-between items-center py-4',
+  logo: 'h-14 w-14',
+  hamburgerIcon: 'w-6 h-6',
   sidebar:
-    "fixed right-0 top-0 w-64 h-full bg-[#117D9C] text-white transform transition-transform duration-300 ease-in-out",
-  sidebarOpen: "translate-x-0",
-  sidebarClosed: "translate-x-full",
-  closeButton: "absolute top-0 right-0 p-4",
-  closeButtonIcon: "w-6 h-6",
-  navItems: "flex flex-col gap-y-5 px-5 py-20",
-};
+    'fixed right-0 top-0 w-64 h-full bg-[#117D9C] text-white transform transition-transform duration-300 ease-in-out',
+  sidebarOpen: 'translate-x-0',
+  sidebarClosed: 'translate-x-full',
+  closeButton: 'absolute top-0 right-0 p-4 ',
+  closeButtonIcon: 'w-6 h-6',
+  navItems: 'flex flex-col gap-y-5 px-5 py-20',
+}
 
 const MobileNavbar = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false)
 
-  const toggleSidebar = () => setIsOpen(!isOpen);
-  const closeSidebar = () => setIsOpen(false);
+  const toggleSidebar = () => setIsOpen(!isOpen)
+  const closeSidebar = () => setIsOpen(false)
 
   return (
     <div className={styles.container}>
@@ -36,7 +36,6 @@ const MobileNavbar = () => {
           onClick={toggleSidebar}
           className={styles.hamburgerIcon}
         >
-          {/* SVG for hamburger icon remains as is, styled by `styles.hamburgerIcon` */}
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
@@ -51,13 +50,23 @@ const MobileNavbar = () => {
       <div
         className={`${isOpen ? styles.sidebarOpen : styles.sidebarClosed} ${styles.sidebar}`}
       >
-        <button onClick={closeSidebar} className={styles.closeButton}>
-          {/* SVG for close button remains as is, styled by `styles.closeButton` */}
-          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <button
+          type="button"
+          onClick={closeSidebar}
+          className="absolute top-0 right-0 rounded-md p-6 text-white"
+        >
+          <svg
+            className="h-6 w-6"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="white"
+            aria-hidden="true"
+          >
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
-              strokeWidth={2}
+              strokeWidth="2"
               d="M6 18L18 6M6 6l12 12"
             />
           </svg>
@@ -70,7 +79,7 @@ const MobileNavbar = () => {
         </div>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default MobileNavbar;
+export default MobileNavbar

--- a/app/components/nav/NavMobile.tsx
+++ b/app/components/nav/NavMobile.tsx
@@ -17,6 +17,7 @@ const styles = {
   closeButton: "absolute top-0 right-0 p-4 ",
   closeButtonIcon: "w-6 h-6",
   navItems: "flex flex-col gap-y-5 pl-12 py-20",
+  overlay: "fixed inset-0 bg-[#117D9C] bg-opacity-40 z-1",
 };
 
 const MobileNavbar = () => {
@@ -46,6 +47,8 @@ const MobileNavbar = () => {
           </svg>
         </button>
       </div>
+
+      {isOpen && <div className={styles.overlay} onClick={closeSidebar}></div>}
 
       <div
         className={`${isOpen ? styles.sidebarOpen : styles.sidebarClosed} ${styles.sidebar}`}

--- a/app/components/nav/NavMobile.tsx
+++ b/app/components/nav/NavMobile.tsx
@@ -1,29 +1,29 @@
-'use client'
+"use client";
 
-import React, { useState } from 'react'
-import Image from 'next/image'
-import MobileLogo from '@/public/Mobile_Logo.svg'
-import Link from 'next/link'
+import React, { useState } from "react";
+import Image from "next/image";
+import MobileLogo from "@/public/Mobile_Logo.svg";
+import Link from "next/link";
 
 const styles = {
-  container: 'relative md:hidden',
-  header: 'flex justify-between items-center py-4',
-  logo: 'h-14 w-14',
-  hamburgerIcon: 'w-6 h-6',
+  container: "relative md:hidden",
+  header: "flex justify-between items-center py-4",
+  logo: "h-14 w-14",
+  hamburgerIcon: "w-6 h-6",
   sidebar:
-    'fixed right-0 top-0 w-64 h-full bg-[#117D9C] text-white transform transition-transform duration-300 ease-in-out',
-  sidebarOpen: 'translate-x-0',
-  sidebarClosed: 'translate-x-full',
-  closeButton: 'absolute top-0 right-0 p-4 ',
-  closeButtonIcon: 'w-6 h-6',
-  navItems: 'flex flex-col gap-y-5 px-5 py-20',
-}
+    "fixed right-0 top-0 w-64 h-full bg-[#117D9C] text-white transform transition-transform duration-300 ease-in-out",
+  sidebarOpen: "translate-x-0",
+  sidebarClosed: "translate-x-full",
+  closeButton: "absolute top-0 right-0 p-4 ",
+  closeButtonIcon: "w-6 h-6",
+  navItems: "flex flex-col gap-y-5 pl-12 py-20",
+};
 
 const MobileNavbar = () => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(false);
 
-  const toggleSidebar = () => setIsOpen(!isOpen)
-  const closeSidebar = () => setIsOpen(false)
+  const toggleSidebar = () => setIsOpen(!isOpen);
+  const closeSidebar = () => setIsOpen(false);
 
   return (
     <div className={styles.container}>
@@ -79,7 +79,7 @@ const MobileNavbar = () => {
         </div>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default MobileNavbar
+export default MobileNavbar;

--- a/app/components/nav/NavMobile.tsx
+++ b/app/components/nav/NavMobile.tsx
@@ -18,6 +18,8 @@ const styles = {
   closeButtonIcon: "w-6 h-6",
   navItems: "flex flex-col gap-y-5 pl-12 py-20",
   overlay: "fixed inset-0 bg-[#117D9C] bg-opacity-40 z-1",
+  linkStyle:
+    "hover:underline hover:underline-offset-4 decoration-2 hover:decoration-[#F0C808]",
 };
 
 const MobileNavbar = () => {
@@ -76,9 +78,23 @@ const MobileNavbar = () => {
         </button>
 
         <div className={styles.navItems}>
-          <Link href="/">Home</Link>
-          <Link href="/#lessons">Lessons</Link>
-          <Link href="/online-resources">Free Online Resources</Link>
+          <Link href="/" onClick={closeSidebar} className={styles.linkStyle}>
+            Home
+          </Link>
+          <Link
+            href="/#lessons"
+            onClick={closeSidebar}
+            className={styles.linkStyle}
+          >
+            Lessons
+          </Link>
+          <Link
+            href="/online-resources"
+            onClick={closeSidebar}
+            className={styles.linkStyle}
+          >
+            Free Online Resources
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- [x] There should be a close button on the menu. 
- [x] There should also be a soft overlay of blue on the quarter of the screen that isn’t covered by the menu.
- [x] The user should have the chance to click out of the screen.
- [x] This might be a preference, but maybe the menu items could be shifted to the right a little more. Maybe a step or two to the right.
- [x] Once I click on any of the menu items, I can not close or click out to view the page. 
- [x] Similar to the desktop version, there should be an indicator when the user clicks on a menu item.