### PR TITLE
Content Request Form

### DIFF
--- a/app/components/landing/ContentRequest.tsx
+++ b/app/components/landing/ContentRequest.tsx
@@ -3,7 +3,7 @@ import { contentRequestForm } from "@/app/constants/siteLinks";
 
 const styles = {
   text: "md:text-[18px] italic",
-  formLink: "text-blue-600 underline",
+  formLink: "text-[#1282A2] underline",
 };
 
 function ContentRequest() {

--- a/app/components/landing/ContentRequest.tsx
+++ b/app/components/landing/ContentRequest.tsx
@@ -1,0 +1,25 @@
+import { BodyRegular } from "@/app/ui/Texts";
+
+const styles = {
+  text: "md:text-[18px] italic",
+  formLink: "text-blue-600 underline",
+};
+
+function ContentRequest() {
+  return (
+    <BodyRegular className={styles.text}>
+      Have requests for additional resources? Fill out our&nbsp;
+      <a
+        href="https://bit.ly/3JTfH8N"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.formLink}
+      >
+        content request form
+      </a>
+      .
+    </BodyRegular>
+  );
+}
+
+export default ContentRequest;

--- a/app/components/landing/ContentRequest.tsx
+++ b/app/components/landing/ContentRequest.tsx
@@ -1,4 +1,5 @@
 import { BodyRegular } from "@/app/ui/Texts";
+import { contentRequestForm } from "@/app/constants/siteLinks";
 
 const styles = {
   text: "md:text-[18px] italic",
@@ -10,7 +11,7 @@ function ContentRequest() {
     <BodyRegular className={styles.text}>
       Have requests for additional resources? Fill out our&nbsp;
       <a
-        href="https://bit.ly/3JTfH8N"
+        href={contentRequestForm}
         target="_blank"
         rel="noopener noreferrer"
         className={styles.formLink}

--- a/app/constants/siteLinks.ts
+++ b/app/constants/siteLinks.ts
@@ -1,0 +1,1 @@
+export const contentRequestForm = "https://bit.ly/3JTfH8N";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,12 +2,14 @@ import styles from "@/app/page.module.css";
 import LandingHero from "@/app/components/landing/LandingHero";
 import LessonsGrid from "@/app/components/landing/LessonsGrid";
 import SponsorsRow from "@/app/components/landing/Sponsors";
+import ContentRequest from "./components/landing/ContentRequest";
 
 export default async function Home() {
   return (
     <main className={styles.main}>
       <LandingHero />
       <LessonsGrid />
+      <ContentRequest />
       <SponsorsRow />
     </main>
   );


### PR DESCRIPTION
Fixes issue #33 , add line on landing page for content request form. 

Adds component for landing page, link will lead to a different tab. 

Add file in constants for general site links, where later down the line we can add as a contentful component. 



#### Before pics:

n/a, did not exists

#### After:

<img width="500" alt="image" src="https://github.com/specollective/Tech4allBiz/assets/92892101/0c32c6ad-37c7-452b-ac2b-1139faacf1e2">
<img width="250" alt="image" src="https://github.com/specollective/Tech4allBiz/assets/92892101/04dbd18e-3c87-4ea4-afc2-bd8f5daa4a40">
